### PR TITLE
Fix compilation on clang / OSX

### DIFF
--- a/pred_src/util/gopt.h
+++ b/pred_src/util/gopt.h
@@ -25,7 +25,8 @@ read http://www.purposeful.co.uk/tfl/
 #define GOPT_NOARG  0
 #define GOPT_ARG    2
 
-#define gopt_start(...)  (const void*)( const struct { int k; int f; const char *s; const char*const*l; }[]){ __VA_ARGS__, {0}}
+typedef struct { int k; int f; const char *s; const char*const*l; } kfsl;
+#define gopt_start(...)  (const void*)( const kfsl[]){ __VA_ARGS__, {0}}
 #define gopt_option(k,f,s,l)    { k, f, s, l }
 #define gopt_shorts( ... )      (const char*)(const char[]){ __VA_ARGS__, 0 }
 #define gopt_longs( ... )       (const char**)(const char*[]){ __VA_ARGS__, NULL }


### PR DESCRIPTION
Fixes #110. Compilation was failing on clang errors like this:

```
    /Users/johnboiles/cusf-standalone-predictor/pred_src/pred.c:50:44: error: expected ';' after struct
        void *options = gopt_sort(&argc, argv, gopt_start(
                                               ^
    /Users/johnboiles/cusf-standalone-predictor/pred_src/util/gopt.h:28:106: note: expanded from macro 'gopt_start'
    #define gopt_start(...)  (const void*)( const struct { int k; int f; const char *s; const char*const*l; }[]){ __VA_ARGS__, {0}}
                                                                                                             ^
```

The fix is to break out the struct definition onto a separate line.
